### PR TITLE
Handle string literals in square bracket notation

### DIFF
--- a/lib/replacer.js
+++ b/lib/replacer.js
@@ -62,16 +62,25 @@ function replaceNodeStrings (sourceRef, nodes, newStr) {
   var offset = 0;
   _.each(nodes, function (node) {
     var prevLength = sourceRef.length;
-    sourceRef = replaceString(sourceRef, newStr, node.start + offset, node.end + offset);
+    var quoteOffset = Number(node.type === 'Literal');
+    sourceRef = replaceString(
+      sourceRef,
+      newStr,
+      node.start + offset + quoteOffset,
+      node.end + offset - quoteOffset
+    );
     offset += (sourceRef.length - prevLength);
   });
   return sourceRef;
 }
 
 function getPropertyNodes (globalNode, propertyName) {
-  var properties = _.where(globalNode.properties, {name: propertyName});
+  var properties = _.filter(globalNode.properties, function (node) {
+    return node.name === propertyName || node.value === propertyName;
+  });
   var hiddenNodes = _.filter(globalNode.passedNodes, function (passedNode) {
-    return passedNode.property && passedNode.property.name === propertyName;
+    var prop = passedNode.property;
+    return prop && (prop.name === propertyName || prop.value === propertyName);
   });
   var hiddenNodeProperties = _.pluck(hiddenNodes, 'property');
   return _.sortBy(properties.concat(hiddenNodeProperties), 'start');

--- a/test/replacer-test.js
+++ b/test/replacer-test.js
@@ -142,6 +142,17 @@ describe('Global replacer', function () {
     });
   });
 
+  describe('replacing square brackets', function () {
+    it('should replace string literal', function () {
+      var s = replacer('window["location"]', {
+        replacements: {
+          'window.location': 'window._l_ocation'
+        }
+      });
+      expect(s).to.be.eql('window["_l_ocation"]');
+    });
+  });
+
   /**
    * TODO specific cases for such cases:
    * - global


### PR DESCRIPTION
This handles replacement like so... `window["location"] -> window["_location"]`
Fixes https://github.com/alexjesp/global-replacer/issues/9
