### PR TITLE
Handle unused passed global variables

### DIFF
--- a/lib/find-globals.js
+++ b/lib/find-globals.js
@@ -105,25 +105,27 @@ module.exports = function findGlobals (source, options) {
    */
   walk.ancestor(ast, {
     'MemberExpression': function (node, parents) {
+      // expression starts on a global node, so add it to
+      // global property group
       if (globals.indexOf(node.object) !== -1) {
         groupedProperties[node.object.name] = groupedProperties[node.object.name] || [];
         groupedProperties[node.object.name].push(node.property);
       }
-      // otherwise check if global was passed as parameter
+      // check if in any of the parent function calls pass in a global
       parents.forEach(function (parent) {
-        // not a function call
         if (parent.type !== 'CallExpression') {
           return;
         }
         parent.arguments.forEach(function (arg, i) {
-          // no global arguments
           if (globals.indexOf(arg) === -1) {
             return;
           }
+          // parent function call is passed global variable as a parameter
           if (parent.callee.type === 'FunctionExpression') {
             var param = parent.callee.params[i];
-            // property accessed off a passed global
-            if (node.object.name === param.name) {
+            // passed global is actually used inside function and one
+            // of it's properties is accessed
+            if (param && node.object.name === param.name) {
               passedGlobals[arg.name] = passedGlobals[arg.name] || [];
               passedGlobals[arg.name].push(node);
             }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "semistandard": {
     "ignore": [
-      "./example*.js"
+      "examples/*.js"
     ]
   },
   "author": "Alexander Esp <alexjesp@gmail.com>",

--- a/test/replacer-test.js
+++ b/test/replacer-test.js
@@ -122,6 +122,16 @@ describe('Global replacer', function () {
     expect(s).to.be.eql('(function (w) {\n  w._l_ocation.href = "www.howaboutthat.com";\n}) (window);');
   });
 
+  it('should ignore passed globals that aren\'t used', function () {
+    var str = '(function () {\n document.addEventListener();\n}) (window);';
+    var s = replacer(str, {
+      replacements: {
+        'window.location': 'window._l_ocation'
+      }
+    });
+    expect(s).to.be.eql(str);
+  });
+
   describe('replacing multiple parts', function () {
     it('should replace multiple parts of global expressions', function () {
       var s = replacer('document.location.href;', {


### PR DESCRIPTION
Previously wasn't handling the case where passed global variable weren't used. E.g.

``` js
(function () {
  var x = 5;
  // ... no use of 'window'
})(window);
```
