### PR TITLE
Don't replace globals with unspecified properties

### DIFF
--- a/lib/replacer.js
+++ b/lib/replacer.js
@@ -43,10 +43,11 @@ function replaceGlobal (sourceRef, globals, from, to, replacerOptions) {
       return replaceNodeStrings(sourceRef, globalNode.nodes, toParts[0]);
     }
     // only replace the globals that have specified property too
-    var globalsThatAlsoHaveProperties = globalNode.nodes.filter(function (node) {
-      return sourceRef[node.end] === '.';
+    var globalsWithCorrectProperty = globalNode.nodes.filter(function (node) {
+      var propertyString = sourceRef.slice(node.end, node.end + fromParts[1].length + 1).join('');
+      return propertyString === ('.' + fromParts[1]);
     });
-    sourceRef = replaceNodeStrings(sourceRef, globalsThatAlsoHaveProperties, toParts[0]);
+    sourceRef = replaceNodeStrings(sourceRef, globalsWithCorrectProperty, toParts[0]);
     // since we have changed the global name, we need to rescan global properties e.g.
     // (window.location -> _window._l_ocation) becomes (_window.location -> _window._l_ocation)
     var newFrom = [toParts[0]].concat(fromParts.slice(1)).join('.');

--- a/test/replacer-test.js
+++ b/test/replacer-test.js
@@ -150,6 +150,15 @@ describe('Global replacer', function () {
       });
       expect(s).to.be.eql('window._l_ocation; document;');
     });
+
+    it('shouldn\'t replace globals for properties other than the one specified', function () {
+      var s = replacer('document.location; document.styleSheets;', {
+        replacements: {
+          'document.location': 'window._l_ocation'
+        }
+      });
+      expect(s).to.be.eql('window._l_ocation; document.styleSheets;');
+    });
   });
 
   /**


### PR DESCRIPTION
``` js
replacer('document.location; document.addEventListener();', {
  replacements: {
    'document.location': 'window._l_ocation'
  }
});
```

used to yield `window._l_ocation; window.addEventListener();` (incorrectly replacing the second occurrence of 'document'. Now, I more stringently make sure that the global instance being replaced has the correct property.
